### PR TITLE
Fixed class name repackage error

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
    1. After opening, specify the SDK (version 11 +, language level = SDK Default ) and make sure the java folders are marked as sources root and test root respectively.  
    2. Quit intelliJ (cmd + q or alt - f4) and open it again.
    3. Open the [UserTest](src/test/java/UserTest.java) file, hover on the import statement for JUnit and add it to the class path. 
-   4. Hover on the entities.User reference, and select add dependency main.
-3. Create a users.ser and a properties.ser file in scr. Run externalinterfaces.InitDatabaseUser and externalinterfaces.InitDatabaseProperty.
-4. Compile and run the `externalinterfaces.RunCLI` class to see the use case for phase zero.  
+   4. Hover on the User reference, and select add dependency main.
+3. Create a users.ser and a properties.ser file in src. Run InitDatabaseUser and InitDatabaseProperty.
+4. Compile and run the `RunCLI` class to see the use case for phase zero.  
 5. Access our CRC cards on Google Slides with [this link](https://docs.google.com/presentation/d/1Mu9Qdts7k7ZLW-95XuRka-Ors4-egG93xTJBwq6y4vs/edit?usp=sharing).   
 6. Access our progress report on Google Slides with [this link](https://docs.google.com/presentation/d/1oNdV-nw-VKgX509FwUFzya7Wf3CHYTNlH2xfX2xgvPQ/edit?usp=sharing).
 7. See the specification at [/phase0/specification.md](phase0/specification.md).

--- a/phase0/specification.md
+++ b/phase0/specification.md
@@ -7,7 +7,7 @@ For properties:
 
 For "purchasing":
 	
-	- entities.Buyer(s) should be able to send an offer to seller for a given real estate.
+	- Buyer(s) should be able to send an offer to seller for a given real estate.
 	- A seller should be able to view their current offers and accept or reject a given offer.
 
 We also want to enable a buyer to join / leave a group of buyers.


### PR DESCRIPTION
Removed package name from all instances of class names in README and specification files